### PR TITLE
Fixing the end cursor behaviour for CurrencyTextFieldController

### DIFF
--- a/lib/currency_textfield.dart
+++ b/lib/currency_textfield.dart
@@ -22,21 +22,21 @@ class CurrencyTextFieldController extends TextEditingController {
   String get decimalSymbol => _decimalSymbol;
   String get thousandSymbol => _thousandSymbol;
 
-  CurrencyTextFieldController(
-      {String rightSymbol = "R\$ ",
-      String decimalSymbol = ",",
-      String thousandSymbol = "."})
-      : _leftSymbol = rightSymbol,
+  CurrencyTextFieldController({String leftSymbol = "R\$ ", String decimalSymbol = ",", String thousandSymbol = "."})
+      : _leftSymbol = leftSymbol,
         _decimalSymbol = decimalSymbol,
         _thousandSymbol = thousandSymbol {
     addListener(_listener);
   }
 
-  _listener() {
+  void _listener() {
     if (_previewsText == text) {
+      // _setSelectionBy(offset: text.length);
       if (_clear(text: text).length == _maxDigits) {
         _setSelectionBy(offset: text.length);
       }
+
+      // _setSelectionBy(offset: text.length);
       return;
     }
 
@@ -74,14 +74,10 @@ class CurrencyTextFieldController extends TextEditingController {
   }
 
   String _clear({required String text}) {
-    return text
-        .replaceAll(_leftSymbol, "")
-        .replaceAll(_thousandSymbol, "")
-        .replaceAll(_decimalSymbol, "")
-        .trim();
+    return text.replaceAll(_leftSymbol, "").replaceAll(_thousandSymbol, "").replaceAll(_decimalSymbol, "").trim();
   }
 
-  _setSelectionBy({required int offset}) {
+  void _setSelectionBy({required int offset}) {
     selection = TextSelection.fromPosition(TextPosition(offset: offset));
   }
 
@@ -93,8 +89,7 @@ class CurrencyTextFieldController extends TextEditingController {
     return clearText != null ? (clearText.length == string.length) : false;
   }
 
-  String? _getOnlyNumbers({String? string}) =>
-      string == null ? null : string.replaceAll(_onlyNumbersRegex, "");
+  String? _getOnlyNumbers({String? string}) => string == null ? null : string.replaceAll(_onlyNumbersRegex, "");
 
   String _formatToNumber({required String string}) {
     double value = _getDoubleValueFor(string: string);
@@ -107,12 +102,8 @@ class CurrencyTextFieldController extends TextEditingController {
   }
 
   String _applyMaskTo({required double value}) {
-    List<String> textRepresentation = value
-        .toStringAsFixed(_numberOfDecimals)
-        .replaceAll(".", "")
-        .split("")
-        .reversed
-        .toList(growable: true);
+    List<String> textRepresentation =
+        value.toStringAsFixed(_numberOfDecimals).replaceAll(".", "").split("").reversed.toList(growable: true);
 
     textRepresentation.insert(_numberOfDecimals, _decimalSymbol);
 

--- a/lib/currency_textfield.dart
+++ b/lib/currency_textfield.dart
@@ -31,12 +31,7 @@ class CurrencyTextFieldController extends TextEditingController {
 
   void _listener() {
     if (_previewsText == text) {
-      // _setSelectionBy(offset: text.length);
-      if (_clear(text: text).length == _maxDigits) {
-        _setSelectionBy(offset: text.length);
-      }
-
-      // _setSelectionBy(offset: text.length);
+      _setSelectionBy(offset: text.length);
       return;
     }
 

--- a/test/currency_textfield_test.dart
+++ b/test/currency_textfield_test.dart
@@ -19,8 +19,7 @@ void main() {
   });
 
   test('test_change_symbols_constructor', () {
-    final controller = CurrencyTextFieldController(
-        rightSymbol: "RR", decimalSymbol: ".", thousandSymbol: ",");
+    final controller = CurrencyTextFieldController(leftSymbol: "RR", decimalSymbol: ".", thousandSymbol: ",");
 
     expect(controller.thousandSymbol, ",");
     expect(controller.leftSymbol, "RR");
@@ -41,9 +40,7 @@ void main() {
     expect(controller.doubleValue, 0.0);
   });
 
-  test(
-      'test_insert_some_inputs_and_after_tryToInsertAValue_greatherThan_maximumValue',
-      () {
+  test('test_insert_some_inputs_and_after_tryToInsertAValue_greatherThan_maximumValue', () {
     final controller = CurrencyTextFieldController();
     controller.text = "99";
     expect(controller.text, 'R\$ 0,99');


### PR DESCRIPTION
### Key changes:
- Added fix to ensure selection is being set to the end of the input at the event if the actual text matches the preview text
- Slight housekeeping (data type specification and parameter renaming)

<b>Before fix:</b> https://photos.app.goo.gl/zdY4THDufFqUpjMA6
<b>After fix:</b> https://photos.app.goo.gl/gh9MSNdRs9uBJck16

### About the fix:
Under the condition of when the _previewsText matches the text, as soon as a return is triggered in the listener, the controller's selection no longer remembers the baseOffset the moment the listener is triggered again, based on what is observed when debugging, even after _setSelectionBy has long been triggered.

Therefore the fix is to set the selection under said condition, and the cursor behaviour overall is restored.